### PR TITLE
Add flag that allows user to set the timestamp format

### DIFF
--- a/rofi-screenshot
+++ b/rofi-screenshot
@@ -112,6 +112,29 @@ check_deps() {
   fi
 }
 
+show_help() {
+  echo ### rofi-screenshot
+  echo "USAGE: rofi-screenshot [OPTION] <argument>"
+  echo "(no option)"
+  echo "    show the screenshot menu"
+  echo "-s, --stop"
+  echo "    stop recording"
+  echo "-h, --help"
+  echo "    this screen"
+  echo "-d, --directory <directory>"
+  echo "    set the screenshot directory"
+  echo "-t, --timestamp <format>"
+  echo "    set the format used for timestamps, in the format the date"
+  echo "    command expects (default '+%d-%m-%Y %H:%M:%S')"
+}
+
+check_directory() {
+  if [[ ! -d $1 ]]; then
+    echo "Directory does not exist!"
+    exit 1
+  fi
+}
+
 main() {
   # check dependencies
   check_deps slop
@@ -120,40 +143,40 @@ main() {
   check_deps xclip
   check_deps rofi
 
-  if [[ $1 == '--help' ]] || [[ $1 = '-h' ]]; then
-    echo ### rofi-screenshot
-    echo "USAGE: rofi-screenshot [OPTION] <argument>"
-    echo "(no option)"
-    echo "    show the screenshot menu"
-    echo "-s, --stop"
-    echo "    stop recording"
-    echo "-h, --help"
-    echo "    this screen"
-    echo "-d, --directory <directory>"
-    echo "    set the screenshot directory"
-    echo "-t, --timestamp <format>"
-    echo "    set the format used for timestamps, in the format the date"
-    echo "    command expects (default '+%d-%m-%Y %H:%M:%S')"
-    exit 1
-  fi
+  # rebind long args as short ones
+  for arg in "$@"; do
+    shift
+    case "$arg" in
+      '--help') set -- "$@" '-h' ;;
+      '--directory') set -- "$@" '-d' ;;
+      '--timestamp') set -- "$@" '-t' ;;
+      *) set -- "$@" "$arg" ;;
+    esac
+  done
 
-  if [[ $1 = '--stop' ]] || [[ $1 = '-s' ]]; then
-    pkill -fxn '(/\S+)*ffmpeg\s.*\sx11grab\s.*'
-    exit 1
-  fi
-
-  if [[ $1 = '--directory' ]] || [[ $1 = '-d' ]]; then
-    if [[ ! -d $2 ]]; then
-      echo "Directory does not exist!"
-      exit 1
-    fi
-    screenshot_directory="$2"
-  fi
-
+  # parse short options
+  OPTIND=1
   date_format="$default_date_format"
-  if [[ $1 = '--timestamp' ]] || [[ $1 = '-t' ]]; then
-    date_format="$2"
-  fi
+  while getopts "hd:t:" opt; do
+    case "$opt" in
+      'h')
+        show_help
+        exit 0
+        ;;
+      'd')
+        check_directory $OPTARG
+        screenshot_directory="$OPTARG"
+        ;;
+      't')
+        date_format="$OPTARG"
+        ;;
+      '?')
+        show_help
+        exit 1
+        ;;
+    esac
+  done
+  shift $(expr $OPTIND - 1)
 
   # Get choice from rofi
   choice=$( (get_options) | rofi -dmenu -i -fuzzy -p "Screenshot")

--- a/rofi-screenshot
+++ b/rofi-screenshot
@@ -10,6 +10,12 @@
 # Screenshot directory
 screenshot_directory="$HOME/Pictures/Screenshots"
 
+# Config location
+config_path="$HOME/.config/rofi-screenshot"
+
+# Default date format
+default_date_format="+%d-%m-%Y %H:%M:%S"
+
 # set ffmpeg defaults
 ffmpeg() {
     command ffmpeg -hide_banner -loglevel error -nostdin "$@"
@@ -39,7 +45,7 @@ crtc() {
 
 crtf() {
   notify-send --app-name="screenshot" "Screenshot" "Select a region to capture"
-  dt=$(date '+%d-%m-%Y %H:%M:%S')
+  dt=$1
   ffcast -q "$(slop -n -f '-g %g ')" png "$screenshot_directory/$dt.png"
   notify-send --app-name="screenshot" "Screenshot" "Region saved to ${screenshot_directory//${HOME}/~}"
 }
@@ -52,14 +58,14 @@ cstc() {
 }
 
 cstf() {
-  dt=$(date '+%d-%m-%Y %H:%M:%S')
+  dt=$1
   ffcast -q png "$screenshot_directory/$dt.png"
   notify-send --app-name="screenshot" "Screenshot" "Saved to ${screenshot_directory//${HOME}/~}"
 }
 
 rgrtf() {
   notify-send --app-name="screenshot" "Screenshot" "Select a region to record"
-  dt=$(date '+%d-%m-%Y %H:%M:%S')
+  dt=$1
   ffcast -q "$(slop -n -f '-g %g ' && countdown)" rec /tmp/screenshot_gif.mp4
   notify-send --app-name="screenshot" "Screenshot" "Converting to gif… (can take a while)"
   video_to_gif /tmp/screenshot_gif.mp4 "$screenshot_directory/$dt.gif"
@@ -69,7 +75,7 @@ rgrtf() {
 
 rgstf() {
   countdown
-  dt=$(date '+%d-%m-%Y %H:%M:%S')
+  dt=$1
   ffcast -q rec /tmp/screenshot_gif.mp4
   notify-send --app-name="screenshot" "Screenshot" "Converting to gif… (can take a while)"
   video_to_gif /tmp/screenshot_gif.mp4 "$screenshot_directory/$dt.gif"
@@ -79,14 +85,14 @@ rgstf() {
 
 rvrtf() {
   notify-send --app-name="screenshot" "Screenshot" "Select a region to record"
-  dt=$(date '+%d-%m-%Y %H:%M:%S')
+  dt=$1
   ffcast -q "$(slop -n -f '-g %g ' && countdown)" rec "$screenshot_directory/$dt.mp4"
   notify-send --app-name="screenshot" "Screenshot" "Saved to ${screenshot_directory//${HOME}/~}"
 }
 
 rvstf() {
   countdown
-  dt=$(date '+%d-%m-%Y %H:%M:%S')
+  dt=$1
   ffcast -q rec "$screenshot_directory/$dt.mp4"
   notify-send --app-name="screenshot" "Screenshot" "Saved to ${screenshot_directory//${HOME}/~}"
 }
@@ -148,6 +154,10 @@ main() {
     screenshot_directory="$2"
   fi
 
+  date_format="$default_date_format"
+  if [[ -f $config_path ]]; then
+    source $config_path
+  fi
 
   # Get choice from rofi
   choice=$( (get_options) | rofi -dmenu -i -fuzzy -p "Screenshot" )
@@ -157,31 +167,34 @@ main() {
       exit 1
   fi
 
+  cmd='date "${date_format}"'
+  dt=$(eval $cmd)
+
   # run the selected command
   case $choice in
     '  Region  Clip')
       crtc
       ;;
     '  Region  File')
-      crtf
+      crtf "$dt"
       ;;
     '  Screen  Clip')
       cstc
       ;;
     '  Screen  File')
-      cstf
+      cstf "$dt"
       ;;
     '  Region  File (GIF)')
-      rgrtf
+      rgrtf "$dt"
       ;;
     '  Screen  File (GIF)')
-      rgstf
+      rgstf "$dt"
       ;;
     '  Region  File (MP4)')
-      rvrtf
+      rvrtf "$dt"
       ;;
     '  Screen  File (MP4)')
-      rvstf
+      rvstf "$dt"
       ;;
   esac
 

--- a/rofi-screenshot
+++ b/rofi-screenshot
@@ -10,9 +10,6 @@
 # Screenshot directory
 screenshot_directory="$HOME/Pictures/Screenshots"
 
-# Config location
-config_path="$HOME/.config/rofi-screenshot"
-
 # Default date format
 default_date_format="+%d-%m-%Y %H:%M:%S"
 
@@ -135,6 +132,9 @@ main() {
     echo "    this screen"
     echo "-d, --directory <directory>"
     echo "    set the screenshot directory"
+    echo "-t, --timestamp <format>"
+    echo "    set the format used for timestamps, in the format the date"
+    echo "    command expects (default '+%d-%m-%Y %H:%M:%S')"
     exit 1
   fi
 
@@ -155,8 +155,8 @@ main() {
   fi
 
   date_format="$default_date_format"
-  if [[ -f $config_path ]]; then
-    source $config_path
+  if [[ $1 = '--timestamp' ]] || [[ $1 = '-t' ]]; then
+    date_format="$2"
   fi
 
   # Get choice from rofi

--- a/rofi-screenshot
+++ b/rofi-screenshot
@@ -15,11 +15,11 @@ default_date_format="+%d-%m-%Y %H:%M:%S"
 
 # set ffmpeg defaults
 ffmpeg() {
-    command ffmpeg -hide_banner -loglevel error -nostdin "$@"
+  command ffmpeg -hide_banner -loglevel error -nostdin "$@"
 }
 
 video_to_gif() {
-    ffmpeg -i "$1" -vf palettegen -f image2 -c:v png - |
+  ffmpeg -i "$1" -vf palettegen -f image2 -c:v png - |
     ffmpeg -i "$1" -i - -filter_complex paletteuse "$2"
 }
 
@@ -106,7 +106,7 @@ get_options() {
 }
 
 check_deps() {
-  if ! hash "$1" 2>/dev/null; then
+  if ! hash "$1" 2> /dev/null; then
     echo "Error: This script requires $1"
     exit 1
   fi
@@ -120,8 +120,7 @@ main() {
   check_deps xclip
   check_deps rofi
 
-  if [[ $1 == '--help' ]] || [[ $1 = '-h' ]]
-  then
+  if [[ $1 == '--help' ]] || [[ $1 = '-h' ]]; then
     echo ### rofi-screenshot
     echo "USAGE: rofi-screenshot [OPTION] <argument>"
     echo "(no option)"
@@ -138,16 +137,13 @@ main() {
     exit 1
   fi
 
-  if [[ $1 = '--stop' ]] || [[ $1 = '-s' ]]
-  then
+  if [[ $1 = '--stop' ]] || [[ $1 = '-s' ]]; then
     pkill -fxn '(/\S+)*ffmpeg\s.*\sx11grab\s.*'
     exit 1
   fi
 
-  if [[ $1 = '--directory' ]] || [[ $1 = '-d' ]]
-  then
-    if [[ ! -d $2 ]]
-    then
+  if [[ $1 = '--directory' ]] || [[ $1 = '-d' ]]; then
+    if [[ ! -d $2 ]]; then
       echo "Directory does not exist!"
       exit 1
     fi
@@ -160,11 +156,11 @@ main() {
   fi
 
   # Get choice from rofi
-  choice=$( (get_options) | rofi -dmenu -i -fuzzy -p "Screenshot" )
+  choice=$( (get_options) | rofi -dmenu -i -fuzzy -p "Screenshot")
 
   # If user has not picked anything, exit
-  if [[ -z "${choice// }" ]]; then
-      exit 1
+  if [[ -z "${choice// /}" ]]; then
+    exit 1
   fi
 
   cmd='date "${date_format}"'


### PR DESCRIPTION
The default date format "`+%d-%m-%Y %H:%M:%S`" doesn't work for me; it causes issues with files that [syncthing](https://syncthing.net/) trying to sync screenshots to devices that can't handle files with special characters in the filename.

So I added a 'default' date format, and a flag that allows the user to override what the date format is if they want.

Also pulled the evalling of `date` out of each function and passing in the computed timestamp string into the functions that need it to make it clear they all share the same timestamp format. I also felt it was a bit cleaner than passing the _format_ into each function and each function calling `date` to compute the timestamp string.