### PR TITLE
feat: allow custom date format

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,8 +36,11 @@ $ rofi-screenshot -s
 ```
 **Tip**: Add a keybinding for both of the above commands
 
-By default files will be stored in `$XDG_PICTURES_DIR/Screenshots`, which typically means `~/Pictures/Screenshots`.
-Use `$ROFI_SCREENSHOT_DIR` environment variable to override this default.
+### Configuration
+| environment variable           | default value                   |                                                                                                                     |
+| ------------------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `$ROFI_SCREENSHOT_DIR`         | `$XDG_PICTURES_DIR/Screenshots` | By default files will be stored in `$XDG_PICTURES_DIR/Screenshots`, which typically means `~/Pictures/Screenshots`. |
+| `$ROFI_SCREENSHOT_DATE_FORMAT` | `+%d-%m-%Y %H:%M:%S`            | Possible alternative: `+%Y-%m-%d-%H-%M-%S`                                                                          |
 
 ### Dependencies
 

--- a/rofi-screenshot
+++ b/rofi-screenshot
@@ -11,7 +11,7 @@
 screenshot_directory="${ROFI_SCREENSHOT_DIR:-${XDG_PICTURES_DIR:-$HOME/Pictures}/Screenshots}"
 
 # Default date format
-default_date_format="+%d-%m-%Y %H:%M:%S"
+default_date_format="${ROFI_SCREENSHOT_DATE_FORMAT:-"+%d-%m-%Y %H:%M:%S"}"
 
 # set ffmpeg defaults
 ffmpeg() {


### PR DESCRIPTION
First, thanks for this tidy utility.

## What

This change allows users to set a custom date format using an environment variable `ROFI_SCREENSHOT_DATE_FORMAT`.

## Why?

1. The current hardcoded format contains a space. File names without spaces are simpler to deal with in the terminal.
2. This would allow setting more robust formats. For example, using a date format like `+%Y-%m-%d-%H-%M-%S` will cause the files to always have sane sorting, even when viewed through file trees that may not explicitly support sorting by date (eg. the file tree in your editor).